### PR TITLE
Use supabase repository by default

### DIFF
--- a/src/data/repo.ts
+++ b/src/data/repo.ts
@@ -1,11 +1,9 @@
 // Repository Selector - Single import to switch between implementations
 
-import { mockRepo } from './assignments.mock';
 import { supabaseRepo } from './assignments.supabase';
 
 // Easy switch: Change this single line to switch between implementations
-export const repo = mockRepo;
-// export const repo = supabaseRepo;
+export const repo = supabaseRepo;
 
 // Re-export types for convenience
 export type { AssignmentsRepo, Assignment, Step, TaskStatus, TaskPriority } from './assignments';


### PR DESCRIPTION
## Summary
- default repository switched to supabase implementation
- remove unused mock repository import

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1336aa47c83309e39a277bd5cc7cf