### PR TITLE
Use service account UUID for system-created records

### DIFF
--- a/src/components/AssignmentCard.tsx
+++ b/src/components/AssignmentCard.tsx
@@ -2,6 +2,7 @@ import { Card } from "./ui/card";
 import { Badge } from "./ui/badge";
 import { AssignmentCard as NewAssignmentCard } from "./AssignmentCards";
 import type { Assignment, AssignmentStatus } from "../types/assignment";
+import { SYSTEM_USER_ID } from "../constants";
 
 // Legacy assignment card component for backward compatibility
 export function AssignmentCard({
@@ -77,7 +78,7 @@ export function convertLegacyToAssignment(legacy: any): Assignment {
     description: legacy.description,
     status: (legacy.status?.toLowerCase() || 'in_progress') as AssignmentStatus,
     priority: legacy.priority || 'medium',
-    createdBy: { id: 'system', name: 'System' },
+    createdBy: { id: SYSTEM_USER_ID, name: 'System' },
     assignees: legacy.assignees || [],
     tags: legacy.tags || [],
     dueAt: legacy.due_date,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,2 @@
+// Supabase service account user ID used for system-created records
+export const SYSTEM_USER_ID = '00000000-0000-0000-0000-000000000000';

--- a/src/data/assignments.mock.ts
+++ b/src/data/assignments.mock.ts
@@ -1,5 +1,6 @@
 // Mock Repository Implementation
 import type { AssignmentsRepo, Assignment, Step, TaskStatus } from "./assignments";
+import { SYSTEM_USER_ID } from "../constants";
 
 // Mock data - moved from TasksView with enhanced structure
 const mockAssignments: Assignment[] = [
@@ -10,7 +11,7 @@ const mockAssignments: Assignment[] = [
     status: "in_progress",
     priority: "high",
     progress: 45,
-    created_by: "system",
+    created_by: SYSTEM_USER_ID,
     created_at: "2024-01-10T08:00:00Z",
     assignees: ["db-team", "ops-team"],
     tags: ["database", "upgrade", "production"],
@@ -25,7 +26,7 @@ const mockAssignments: Assignment[] = [
     status: "review",
     priority: "medium",
     progress: 90,
-    created_by: "system",
+    created_by: SYSTEM_USER_ID,
     created_at: "2024-01-09T09:30:00Z",
     assignees: ["dev-team", "api-team"],
     tags: ["api", "security", "redis"],
@@ -50,7 +51,7 @@ const mockAssignments: Assignment[] = [
     status: "todo",
     priority: "high",
     progress: 0,
-    created_by: "system", 
+    created_by: SYSTEM_USER_ID, 
     created_at: "2024-01-08T14:15:00Z",
     assignees: ["k8s-team", "monitoring-team"],
     tags: ["kubernetes", "monitoring", "prometheus"],
@@ -64,7 +65,7 @@ const mockAssignments: Assignment[] = [
     status: "done",
     priority: "critical",
     progress: 100,
-    created_by: "system",
+    created_by: SYSTEM_USER_ID,
     created_at: "2024-01-05T10:00:00Z",
     assignees: ["security-team", "auth-team"],
     tags: ["security", "audit", "oauth"],
@@ -79,7 +80,7 @@ const mockAssignments: Assignment[] = [
     status: "in_progress",
     priority: "medium",
     progress: 60,
-    created_by: "system",
+    created_by: SYSTEM_USER_ID,
     created_at: "2024-01-09T11:00:00Z",
     assignees: ["ci-team", "dev-team"],
     tags: ["ci/cd", "performance", "docker"],
@@ -94,7 +95,7 @@ const mockAssignments: Assignment[] = [
     status: "todo",
     priority: "high",
     progress: 0,
-    created_by: "system",
+    created_by: SYSTEM_USER_ID,
     created_at: "2024-01-08T16:30:00Z",
     assignees: ["security-team", "ops-team"],
     tags: ["ssl", "certificates", "security"],
@@ -108,7 +109,7 @@ const mockAssignments: Assignment[] = [
     status: "review",
     priority: "medium",
     progress: 80,
-    created_by: "system",
+    created_by: SYSTEM_USER_ID,
     created_at: "2024-01-10T12:00:00Z",
     assignees: ["database-team"],
     tags: ["database", "backup", "verification"],

--- a/src/data/assignments.supabase.ts
+++ b/src/data/assignments.supabase.ts
@@ -135,6 +135,7 @@ function convertToLegacyStep(dbStep: DatabaseStep): Step {
 
 // Import users data
 import { users, getRandomUser } from './users';
+import { SYSTEM_USER_ID } from '../constants';
 
 // Fallback mock data
 const getMockAssignments = (statuses?: TaskStatus[]): Assignment[] => {
@@ -151,7 +152,7 @@ const getMockAssignments = (statuses?: TaskStatus[]): Assignment[] => {
       status: 'in_progress',
       priority: 'high',
       progress: 45,
-      created_by: 'system',
+      created_by: SYSTEM_USER_ID,
       created_at: new Date().toISOString(),
       estimated_hours: 16,
       assignees: ['Database Team'],
@@ -164,7 +165,7 @@ const getMockAssignments = (statuses?: TaskStatus[]): Assignment[] => {
       status: 'review',
       priority: 'medium',
       progress: 90,
-      created_by: 'system',
+      created_by: SYSTEM_USER_ID,
       created_at: new Date().toISOString(),
       estimated_hours: 12,
       assignees: ['Backend Team'],
@@ -182,7 +183,7 @@ const getMockAssignments = (statuses?: TaskStatus[]): Assignment[] => {
       status: 'todo',
       priority: 'high',
       progress: 0,
-      created_by: 'system',
+      created_by: SYSTEM_USER_ID,
       created_at: new Date().toISOString(),
       estimated_hours: 20,
       assignees: ['DevOps Team'],
@@ -195,7 +196,7 @@ const getMockAssignments = (statuses?: TaskStatus[]): Assignment[] => {
       status: 'in_progress',
       priority: 'critical',
       progress: 75,
-      created_by: 'system',
+      created_by: SYSTEM_USER_ID,
       created_at: new Date().toISOString(),
       estimated_hours: 8,
       assignees: ['Security Team'],
@@ -208,7 +209,7 @@ const getMockAssignments = (statuses?: TaskStatus[]): Assignment[] => {
       status: 'todo',
       priority: 'medium',
       progress: 10,
-      created_by: 'system',
+      created_by: SYSTEM_USER_ID,
       created_at: new Date().toISOString(),
       estimated_hours: 6,
       assignees: ['Network Team'],
@@ -221,7 +222,7 @@ const getMockAssignments = (statuses?: TaskStatus[]): Assignment[] => {
       status: 'review',
       priority: 'medium',
       progress: 80,
-      created_by: 'system',
+      created_by: SYSTEM_USER_ID,
       created_at: new Date().toISOString(),
       estimated_hours: 4,
       assignees: ['Database Team'],
@@ -412,7 +413,7 @@ CREATE TABLE public.assignments (
   status TEXT NOT NULL CHECK (status IN ('todo','in_progress','review','done')),
   priority TEXT NOT NULL CHECK (priority IN ('low','medium','high','critical')),
   progress INT NOT NULL DEFAULT 0 CHECK (progress BETWEEN 0 AND 100),
-  created_by TEXT NOT NULL, -- or UUID if using auth
+  created_by UUID NOT NULL, -- user id
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   assignees TEXT[], -- array of assignee IDs
   tags TEXT[], -- array of tags

--- a/src/data/assignments.ts
+++ b/src/data/assignments.ts
@@ -9,7 +9,7 @@ export interface Assignment {
   status: TaskStatus;
   priority: TaskPriority;
   progress: number; // 0..100
-  created_by: string; // user id or 'system'
+  created_by: string; // user id (UUID)
   created_at: string;
   assignees?: string[]; // assignee IDs
   tags?: string[];

--- a/src/hooks/useAssignment.ts
+++ b/src/hooks/useAssignment.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { db } from "../utils/supabase/client";
 import type { Assignment } from "../types/assignment";
+import { SYSTEM_USER_ID } from "../constants";
 
 export function useAssignment(id: string | null) {
   const [data, setData] = useState<Assignment | null>(null);
@@ -24,7 +25,7 @@ export function useAssignment(id: string | null) {
           // Convert the database assignment to our Assignment type
           const formattedAssignment: Assignment = {
             ...assignment,
-            createdBy: { id: 'system', name: 'System' }, // Default since we don't have this in DB yet
+            createdBy: { id: SYSTEM_USER_ID, name: 'System' }, // Default since we don't have this in DB yet
             steps: assignment.tags?.map((tag, index) => ({
               id: `step-${index}`,
               title: tag,
@@ -52,7 +53,7 @@ export function useAssignment(id: string | null) {
       if (payload.new?.id === id && active) {
         const updatedAssignment: Assignment = {
           ...payload.new,
-          createdBy: { id: 'system', name: 'System' },
+          createdBy: { id: SYSTEM_USER_ID, name: 'System' },
           steps: payload.new.tags?.map((tag: string, index: number) => ({
             id: `step-${index}`,
             title: tag,

--- a/src/supabase/functions/server/index.tsx
+++ b/src/supabase/functions/server/index.tsx
@@ -40,6 +40,7 @@ import {
   seedLiveAssignments
 } from './supabase-db.tsx';
 import { createClient } from 'npm:@supabase/supabase-js@2.39.0';
+import { SYSTEM_USER_ID } from '../../../constants.ts';
 
 // Create Supabase client for health checks
 const supabaseUrl = Deno.env.get('SUPABASE_URL');
@@ -168,7 +169,7 @@ const getMockAssignments = (statuses?: string[]) => {
       status: 'in_progress',
       priority: 'high',
       progress: 45,
-      created_by: 'system',
+      created_by: SYSTEM_USER_ID,
       created_at: new Date().toISOString(),
       estimated_hours: 16,
       assignee: 'Database Team'
@@ -180,7 +181,7 @@ const getMockAssignments = (statuses?: string[]) => {
       status: 'review',
       priority: 'medium',
       progress: 90,
-      created_by: 'system',
+      created_by: SYSTEM_USER_ID,
       created_at: new Date().toISOString(),
       estimated_hours: 12,
       assignee: 'Backend Team'
@@ -192,7 +193,7 @@ const getMockAssignments = (statuses?: string[]) => {
       status: 'todo',
       priority: 'high',
       progress: 0,
-      created_by: 'system',
+      created_by: SYSTEM_USER_ID,
       created_at: new Date().toISOString(),
       estimated_hours: 20,
       assignee: 'DevOps Team'
@@ -204,7 +205,7 @@ const getMockAssignments = (statuses?: string[]) => {
       status: 'in_progress',
       priority: 'critical',
       progress: 75,
-      created_by: 'system',
+      created_by: SYSTEM_USER_ID,
       created_at: new Date().toISOString(),
       estimated_hours: 8,
       assignee: 'Security Team'
@@ -216,7 +217,7 @@ const getMockAssignments = (statuses?: string[]) => {
       status: 'todo',
       priority: 'medium',
       progress: 10,
-      created_by: 'system',
+      created_by: SYSTEM_USER_ID,
       created_at: new Date().toISOString(),
       estimated_hours: 6,
       assignee: 'Network Team'
@@ -228,7 +229,7 @@ const getMockAssignments = (statuses?: string[]) => {
       status: 'review',
       priority: 'medium',
       progress: 100,
-      created_by: 'system',
+      created_by: SYSTEM_USER_ID,
       created_at: new Date().toISOString(),
       estimated_hours: 4,
       assignee: 'Database Team'
@@ -339,7 +340,7 @@ app.post('/make-server-a7530657/assignments', async (c) => {
       status: assignmentData.status || 'todo',
       priority: assignmentData.priority || 'medium',
       progress: assignmentData.progress || 0,
-      created_by: assignmentData.created_by || 'system',
+      created_by: assignmentData.created_by || SYSTEM_USER_ID,
       due_at: assignmentData.due_at || null,
       estimated_hours: assignmentData.estimated_hours || null,
       assignee: assignmentData.assignee || null

--- a/src/supabase/functions/server/supabase-db.tsx
+++ b/src/supabase/functions/server/supabase-db.tsx
@@ -1,5 +1,6 @@
 import { createClient } from 'npm:@supabase/supabase-js@2.39.0';
 import type { DatabaseAssignment, TriageAssignment } from '../../../types/assignment.ts';
+import { SYSTEM_USER_ID } from '../../../constants.ts';
 
 // Initialize Supabase client for server-side operations with graceful fallback
 const supabaseUrl = Deno.env.get('SUPABASE_URL');
@@ -144,7 +145,7 @@ export async function updateSupabaseAssignment(id: string, updates: Partial<Data
         status: updateData.status || 'todo',
         priority: updateData.priority || 'medium',
         progress: updateData.progress !== undefined ? updateData.progress : 0,
-        created_by: updateData.created_by || 'system',
+        created_by: updateData.created_by || SYSTEM_USER_ID,
         created_at: updateData.created_at || new Date().toISOString(),
         assignee: updateData.assignee || null,
         // Optional fields with safe defaults
@@ -224,7 +225,7 @@ export async function updateSupabaseAssignment(id: string, updates: Partial<Data
         status: updateData.status || 'todo',
         priority: updateData.priority || 'medium',
         progress: updateData.progress !== undefined ? updateData.progress : 0,
-        created_by: updateData.created_by || 'system',
+        created_by: updateData.created_by || SYSTEM_USER_ID,
         created_at: updateData.created_at || new Date().toISOString(),
         assignee: updateData.assignee || null,
         // Safe defaults for all optional fields
@@ -428,7 +429,7 @@ export async function seedLiveAssignments() {
         status: 'in_progress',
         priority: 'high',
         progress: 45,
-        created_by: 'system',
+        created_by: SYSTEM_USER_ID,
         estimated_hours: 16,
         assignee: 'Database Team'
       },
@@ -438,7 +439,7 @@ export async function seedLiveAssignments() {
         status: 'review',
         priority: 'medium',
         progress: 90,
-        created_by: 'system',
+        created_by: SYSTEM_USER_ID,
         estimated_hours: 12,
         assignee: 'Backend Team'
       },
@@ -448,7 +449,7 @@ export async function seedLiveAssignments() {
         status: 'todo',
         priority: 'high',
         progress: 0,
-        created_by: 'system',
+        created_by: SYSTEM_USER_ID,
         estimated_hours: 20,
         assignee: 'DevOps Team'
       },
@@ -458,7 +459,7 @@ export async function seedLiveAssignments() {
         status: 'in_progress',
         priority: 'critical',
         progress: 75,
-        created_by: 'system',
+        created_by: SYSTEM_USER_ID,
         estimated_hours: 8,
         assignee: 'Security Team'
       },
@@ -468,7 +469,7 @@ export async function seedLiveAssignments() {
         status: 'todo',
         priority: 'medium',
         progress: 10,
-        created_by: 'system',
+        created_by: SYSTEM_USER_ID,
         estimated_hours: 6,
         assignee: 'Network Team'
       },
@@ -478,7 +479,7 @@ export async function seedLiveAssignments() {
         status: 'review',
         priority: 'medium',
         progress: 100,
-        created_by: 'system',
+        created_by: SYSTEM_USER_ID,
         estimated_hours: 4,
         assignee: 'Database Team'
       }

--- a/src/types/assignment.ts
+++ b/src/types/assignment.ts
@@ -63,7 +63,7 @@ export interface DatabaseAssignment {
   impact?: string;
   simulation?: string;
   
-  created_by: string;
+  created_by: string; // UUID of creator
   created_at: string;
   estimated_hours?: number;
 


### PR DESCRIPTION
## Summary
- add shared `SYSTEM_USER_ID` constant for the Supabase service account
- replace `created_by: 'system'` with this UUID in assignments and server functions
- document and update mock data so `created_by` is always a UUID

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c133695e4c833087746a2159d182c1